### PR TITLE
Domain-inherited purge limits and various enhancements

### DIFF
--- a/README
+++ b/README
@@ -43,6 +43,9 @@ appropriate options:
 $rcmail_config['purge_driver'] = 'sql';
     so far only sql is available
 
+$rcmail_config['purge_visible'] = boolean;
+    indicates if users can change purge values in their settings
+
 $rcmail_config['purge_sql_dsn'] = value;
     example value: 'pgsql://username:password@host/database'
     example value: 'mysql://username:password@host/database'
@@ -58,6 +61,10 @@ $rcmail_config['purge_sql_read'] = query;
     placeholder %address must be kept unchanged
     default query: 'SELECT * FROM mailbox WHERE username = %username'
     example query: 'SELECT * FROM mailboxes WHERE username = %username'
+
+$rcmail_config['purge_sql_read_domain'] = query;
+    the query depends upon your postfixadmin database structure
+    default query: 'SELECT purge_trash, purge_junk FROM domain WHERE domain = %domain'
 
 $rcmail_config['purge_script_query'] = query;
     the query depends upon your postfixadmin database structure

--- a/SQL
+++ b/SQL
@@ -17,3 +17,33 @@ MySQL
 
 ALTER TABLE mailbox ADD COLUMN purge_trash int(11) NOT NULL DEFAULT 0;
 ALTER TABLE mailbox ADD COLUMN purge_junk int(11) NOT NULL DEFAULT 0;
+
+
+If you want to use domain-wide default values that can be inherited to all users, use these statements instead:
+
+
+PostgreSQL
+----------
+
+ALTER TABLE domain ADD COLUMN purge_trash integer;
+ALTER TABLE domain ALTER COLUMN purge_trash SET NOT NULL;
+ALTER TABLE domain ALTER COLUMN purge_trash SET DEFAULT 0;
+ALTER TABLE domain ADD COLUMN purge_junk integer;
+ALTER TABLE domain ALTER COLUMN purge_junk SET NOT NULL;
+ALTER TABLE domain ALTER COLUMN purge_junk SET DEFAULT 0;
+ALTER TABLE mailbox ADD COLUMN purge_trash integer;
+ALTER TABLE mailbox ALTER COLUMN purge_trash SET NULL;
+ALTER TABLE mailbox ALTER COLUMN purge_trash SET DEFAULT NULL;
+ALTER TABLE mailbox ADD COLUMN purge_junk integer;
+ALTER TABLE mailbox ALTER COLUMN purge_junk SET NULL;
+ALTER TABLE mailbox ALTER COLUMN purge_junk SET DEFAULT NULL;
+
+
+MySQL
+-----
+
+
+ALTER TABLE domain ADD COLUMN purge_trash int(11) NOT NULL DEFAULT 0;
+ALTER TABLE domain ADD COLUMN purge_junk int(11) NOT NULL DEFAULT 0;
+ALTER TABLE mailbox ADD COLUMN purge_trash int(11) NULL DEFAULT NULL;
+ALTER TABLE mailbox ADD COLUMN purge_junk int(11) NULL DEFAULT NULL;

--- a/config.inc.php.dist
+++ b/config.inc.php.dist
@@ -5,6 +5,9 @@
 // Set the driver. Default (and so far the only existing): "sql".
 $rcmail_config['purge_driver'] = 'sql';
 
+// Show purge tab in user's settings or hide it (so that only administrators may change the values)
+$rcmail_config['purge_visible'] = true;
+
 // SQL Driver options
 // ------------------
 // PEAR database DSN for performing the query.
@@ -17,8 +20,11 @@ $rcmail_config['purge_sql_write'] = 'UPDATE mailbox SET purge_trash = %purgetras
 // The SQL query used to select purge data.
 $rcmail_config['purge_sql_read'] = 'SELECT * FROM mailbox WHERE username = %username';
 
+// The SQL query used to select domain-wide purge data.
+$rcmail_config['purge_sql_read_domain'] = 'SELECT purge_trash, purge_junk FROM domain WHERE domain = %domain';
+
 // The SQL query used to get mailboxes for the php script.
-$rcmail_config['purge_script_query'] = 'SELECT domain, local_part, purge_trash, purge_junk FROM mailbox';
+$rcmail_config['purge_script_query'] = 'SELECT domain, local_part, maildir, purge_trash, purge_junk FROM mailbox';
 
 // Path to maildirs.
 $rcmail_config['purge_maildir_path'] = '/web/vmail';

--- a/lib/drivers/sql.php
+++ b/lib/drivers/sql.php
@@ -36,7 +36,7 @@ function purge_folder_read(array &$data) {
 		else if (!is_array($dsn) && !preg_match('/\?new_link=true/', $dsn)) {
 			$dsn .= '?new_link=true';
 			}
-		$db = new rcube_mdb2($dsn, '', FALSE);
+		$db = rcube_db::factory($dsn, '', false);
 		$db->set_debug((bool)$rcmail->config->get('sql_debug'));
 		$db->db_connect('w');
 		}
@@ -48,28 +48,17 @@ function purge_folder_read(array &$data) {
 		return PLUGIN_ERROR_CONNECT;
 		}
 
-	$search = array(
-			'%username'
-			);
-	$replace = array(
-			$db->quote($data['username'])
-			);
-	$query = str_replace($search, $replace, $rcmail->config->get('purge_sql_read'));
-
-	$sql_result = $db->query($query);
-	if ($err = $db->is_error()) {
+	$sql_arr = purge_get_values_for_user($db, $data['username']);
+	if ($sql_arr === null) {
 		return PLUGIN_ERROR_PROCESS;
 		}
 
-	$sql_arr = $db->fetch_assoc($sql_result);
-
-	if (isset($sql_arr['purge_trash'])) { $data['purge_trash'] = $sql_arr['purge_trash']; }
-	else { $data['purge_trash'] = 0; }
-
-	if (isset($sql_arr['purge_junk'])) { $data['purge_junk'] = $sql_arr['purge_junk']; }
-	else { $data['purge_junk'] = 0; }
-
-	return PLUGIN_SUCCESS;
+	$result = purge_set_data($sql_arr, $data, $db, 'purge_trash');
+	if ($result !== PLUGIN_SUCCESS) {
+		return $result;
+	}
+	$result = purge_set_data($sql_arr, $data, $db, 'purge_junk');
+	return $result;
 
 	}
 
@@ -79,7 +68,6 @@ function purge_folder_read(array &$data) {
  * @return: integer the status code.
  */
 function purge_folder_write(array &$data) {
-
 	$rcmail = rcmail::get_instance();
 
 	if ($dsn = $rcmail->config->get('purge_sql_dsn')) {
@@ -89,7 +77,7 @@ function purge_folder_write(array &$data) {
 		else if (!is_array($dsn) && !preg_match('/\?new_link=true/', $dsn)) {
 			$dsn .= '?new_link=true';
 			}
-		$db = new rcube_mdb2($dsn, '', FALSE);
+		$db = rcube_db::factory($dsn, '', false);
 		$db->set_debug((bool)$rcmail->config->get('sql_debug'));
 		$db->db_connect('w');
 		}
@@ -113,13 +101,52 @@ function purge_folder_write(array &$data) {
 			);
 	$query = str_replace($search, $replace, $rcmail->config->get('purge_sql_write'));
 
-	$sql_result = $db->query($query);
+	$db->query($query);
 	if ($err = $db->is_error()) {
 		return PLUGIN_ERROR_PROCESS;
 		}
 
 	return PLUGIN_SUCCESS;
 
+	}
+
+function purge_get_values_for_user($db, $username) {
+	$rcmail = rcmail::get_instance();
+	return purge_query($db, '%username', $username, $rcmail->config->get('purge_sql_read'));
+	}
+
+function purge_get_values_for_domain($db, $domain) {
+	$rcmail = rcmail::get_instance();
+	return purge_query($db, '%domain', $domain, $rcmail->config->get('purge_sql_read_domain'));
+	}
+
+function purge_set_data(&$sql_arr, &$data, $db, $value) {
+	$rcmail = rcmail::get_instance();
+
+	if (isset($sql_arr[$value]) && !empty($sql_arr[$value])) { $data[$value] = $sql_arr[$value]; }
+	else if ($data['domain'] !== null && $rcmail->config->get('purge_sql_read_domain') !== null) {
+		$domain_arr = purge_get_values_for_domain($db, $data['domain']);
+		if ($domain_arr === null) {
+			return PLUGIN_ERROR_PROCESS;
+			}
+
+		$data[$value] = $domain_arr[$value];
+		}
+	else { $data[$value] = 0; }
+	return PLUGIN_SUCCESS;
+	}
+
+function purge_query($db, $placeholder, $value, $query) {
+	$rcmail = rcmail::get_instance();
+
+	$query = str_replace($placeholder, $db->quote($value), $query);
+	$sql_result = $db->query($query);
+	if ($err = $db->is_error()) {
+		return null;
+		}
+
+	$sql_arr = $db->fetch_assoc($sql_result);
+	return $sql_arr;
 	}
 
 ?>

--- a/lib/rcube_purge.php
+++ b/lib/rcube_purge.php
@@ -23,6 +23,7 @@
 class rcube_purge {
 
 	public $username = '';
+	public $domain = '';
 	public $purgetrash = 0;
 	public $purgejunk = 0;
 
@@ -32,11 +33,23 @@ class rcube_purge {
 
 	private function init() {
 		$this->username = rcmail::get_instance()->user->get_username();
+		$this->domain = explode('@', $this->username, 2);
+		if (count($this->domain) < 2) {
+			$this->domain = null;
+			}
+		else {
+			$this->domain = $this->domain[1];
+			}
 		}
 
 	// Gets the username.
 	public function get_username() {
 		return $this->username;
+		}
+
+	// Gets the user's domain.
+	public function get_domain() {
+		return $this->domain;
 		}
 
 	// Gets the days-alive for trash.

--- a/purge.php
+++ b/purge.php
@@ -34,15 +34,16 @@ class purge extends rcube_plugin {
 
 		$rcmail = rcmail::get_instance();
 		$this->rc = &$rcmail;
-		$this->add_texts('localization/', true);
-
-		$this->rc->output->add_label('purge');
-		$this->register_action('plugin.purge', array($this, 'purge_init'));
-		$this->register_action('plugin.purge-save', array($this, 'purge_save'));
-		$this->include_script('purge.js');
-
 		$this->load_config();
-		$this->require_plugin('jqueryui');
+
+		if ($this->rc->config->get('purge_visible', true) === true) {
+			$this->add_texts('localization/', true);
+			$this->rc->output->add_label('purge');
+			$this->register_action('plugin.purge', array($this, 'purge_init'));
+			$this->register_action('plugin.purge-save', array($this, 'purge_save'));
+			$this->include_script('purge.js');
+			$this->require_plugin('jqueryui');
+			}
 
 		require_once ($this->home . '/lib/rcube_purge.php');
 		$this->obj = new rcube_purge();
@@ -132,6 +133,7 @@ class purge extends rcube_plugin {
 
 		$data = array();
 		$data['username'] = $this->obj->username;
+		$data['domain'] = $this->obj->domain;
 
 		$ret = purge_folder_read($data);
 		switch ($ret) {

--- a/purgefolders.php
+++ b/purgefolders.php
@@ -14,72 +14,103 @@
 
 */
 
-require_once 'PEAR.php';
-require_once 'MDB2.php';
-require_once("config.inc.php");
+define('INSTALL_PATH', __DIR__ . '/../../');
+require_once INSTALL_PATH . 'program/include/iniset.php';
 
-$log_file = "/var/log/roundcube/purgefolders.log";
+$rcmail = rcmail::get_instance();
+$rcmail->plugins->load_plugin('purge', true);
+$rcmail->write_log('purgefolders', 'Purge operation started');
 
-$log = fopen($log_file, "a");
-fwrite($log, date('Y-m-d H:i:s') . " - Purge operation started.\n");
-
-$options = array(
-	'persistent' => true
-	);
-
-$db = MDB2::connect($rcmail_config['purge_sql_dsn'], $options);
-if (PEAR::isError($db)) {
-	exit($db->getMessage());
+if ($dsn = $rcmail->config->get('purge_sql_dsn')) {
+	if (is_array($dsn) && empty($dsn['new_link'])) {
+		$dsn['new_link'] = true;
+	}
+	else if (!is_array($dsn) && !preg_match('/\?new_link=true/', $dsn)) {
+		$dsn .= '?new_link=true';
+		}
+	$db = rcube_db::factory($dsn, '', false);
+	$db->set_debug((bool)$rcmail->config->get('sql_debug'));
+	$db->db_connect('w');
+}
+else {
+	$db = $rcmail->get_dbh();
 	}
 
-$sql_result = $db->query($rcmail_config['purge_script_query']);
-if (PEAR::isError($sql_result)) {
-	exit($db->getMessage());
+if ($err = $db->is_error()) {
+	$rcmail->write_log('purgefolders', 'Error connecting to database: ' . $err);
+	exit($err . "\n");
 	}
 
-$mailboxes = $sql_result->fetchAll(MDB2_FETCHMODE_ASSOC);
+$sql_result = $db->query($rcmail->config->get('purge_script_query'));
+if ($err = $db->is_error()) {
+	$rcmail->write_log('purgefolders', 'Error reading mailboxes from database: ' . $err);
+	exit($err . "\n");
+	}
 
+$mailboxes = $sql_result->fetchAll();
 for ( $i = 0 ; $i < count($mailboxes) ; $i++) {
+	$purge_trash = $mailboxes[$i]['purge_trash'];
+	$purge_junk = $mailboxes[$i]['purge_junk'];
+	if (($purge_trash === null || $purge_junk === null) && $rcmail->config->get('purge_sql_read_domain') !== null) {
+		$search = array(
+				'%domain'
+				);
+		$replace = array(
+				$db->quote($mailboxes[$i]['domain'])
+				);
+		$query = str_replace($search, $replace, $rcmail->config->get('purge_sql_read_domain'));
+		$sql_result = $db->query($query);
+		if ($err = $db->is_error()) {
+			$rcmail->write_log('purgefolders', 'Error reading domain quota for ' . $mailboxes[$i]['domain'] . ': ' . $err);
+			exit($err . "\n");
+		    }
+		$sql_arr = $db->fetch_assoc($sql_result);
+
+		if ($purge_trash === null) {
+			$purge_trash = $sql_arr['purge_trash'];
+			}
+		if ($purge_junk === null) {
+			$purge_junk = $sql_arr['purge_junk'];
+			}
+		}
+	$purge_trash = intval($purge_trash);
+	$purge_junk = intval($purge_junk);
+
 	$tcount = 0;
-	$tlast = intval($mailboxes[$i]['purge_trash']) > 0 ? (intval($mailboxes[$i]['purge_trash']) == 1 ? " 1 day" : " " . strval($mailboxes[$i]['purge_trash']) . " days") : "ever";
-	fwrite($log, date('Y-m-d H:i:s') . "     User " .  $mailboxes[$i]['local_part'] . "@" . $mailboxes[$i]['domain'] . " keeps messages in Trash folder for" . $tlast . ".\n");
-	if (intval($mailboxes[$i]['purge_trash']) > 0) {
-		$trash = $rcmail_config['purge_maildir_path'] . "/" . $mailboxes[$i]['domain'] . "/" . $mailboxes[$i]['local_part'] . "/Maildir/.Trash/cur";
+	$tlast = $purge_trash > 0 ? ($purge_trash == 1 ? " 1 day" : " " . strval($purge_trash) . " days") : "ever";
+	$rcmail->write_log('purgefolders', "User " .  $mailboxes[$i]['local_part'] . "@" . $mailboxes[$i]['domain'] . " keeps messages in Trash folder for" . $tlast);
+	if ($purge_trash > 0) {
+		$trash = $rcmail->config->get('purge_maildir_path') . "/" . $mailboxes[$i]['maildir'] . "/.Trash/cur";
 		$files = array_diff(scandir($trash), array('..', '.'));
 		if (!empty($files)) {
 			foreach ($files as $filename) {
-				if ((time() - filemtime($trash . "/" . $filename)) > ($mailboxes[$i]['purge_trash'] * 60 * 60 * 24)) {
-					fwrite($log, date('Y-m-d H:i:s') . "     Purging file " . $filename . " (dated " . date('Y-m-d H:i:s', filemtime($trash . "/" . $filename)) . ") from Trash folder of user " .  $mailboxes[$i]['local_part'] . "@" . $mailboxes[$i]['domain'] . ".\n");
+				if ((time() - filemtime($trash . "/" . $filename)) > ($purge_trash * 60 * 60 * 24)) {
+					$rcmail->write_log('purgefolders', "Purging file " . $filename . " (dated " . date('Y-m-d H:i:s', filemtime($trash . "/" . $filename)) . ") from Trash folder of user " .  $mailboxes[$i]['local_part'] . "@" . $mailboxes[$i]['domain']);
 					unlink($trash . "/" . $filename);
 					$tcount++;
 					}
 				}
 			}
 		}
-	fwrite($log, date('Y-m-d H:i:s') . "       " . $tcount . " messages purged from Trash folder of user " .  $mailboxes[$i]['local_part'] . "@" . $mailboxes[$i]['domain'] . ".\n");
+	$rcmail->write_log('purgefolders', $tcount . " messages purged from Trash folder of user " .  $mailboxes[$i]['local_part'] . "@" . $mailboxes[$i]['domain']);
 	$jcount = 0;
-	$jlast = intval($mailboxes[$i]['purge_junk']) > 0 ? (intval($mailboxes[$i]['purge_junk']) == 1 ? " 1 day" : " " . strval($mailboxes[$i]['purge_junk']) . " days") : "ever";
-	fwrite($log, date('Y-m-d H:i:s') . "     User " .  $mailboxes[$i]['local_part'] . "@" . $mailboxes[$i]['domain'] . " keeps messages in Junk folder for" . $jlast . ".\n");
+	$jlast = $purge_junk > 0 ? ($purge_junk == 1 ? " 1 day" : " " . strval($purge_junk) . " days") : "ever";
+	$rcmail->write_log('purgefolders', "User " .  $mailboxes[$i]['local_part'] . "@" . $mailboxes[$i]['domain'] . " keeps messages in Junk folder for" . $jlast);
 	if (intval($mailboxes[$i]['purge_junk']) > 0) {
-		$junk = $rcmail_config['purge_maildir_path'] . "/" . $mailboxes[$i]['domain'] . "/" . $mailboxes[$i]['local_part'] . "/Maildir/.Junk/cur";
+		$junk = $rcmail->config->get('purge_maildir_path') . "/" . $mailboxes[$i]['maildir'] . "/.Junk/cur";
 		$files = array_diff(scandir($junk), array('..', '.'));
 		if (!empty($files)) {
 			foreach ($files as $filename) {
-				if ((time() - filemtime($junk . "/" . $filename)) > ($mailboxes[$i]['purge_junk'] * 60 * 60 * 24)) {
-					fwrite($log, date('Y-m-d H:i:s') . "     Purging file " . $filename . " (dated " . date('Y-m-d H:i:s', filemtime($trash . "/" . $filename)) . ") from Junk folder of user " .  $mailboxes[$i]['local_part'] . "@" . $mailboxes[$i]['domain'] . ".\n");
+				if ((time() - filemtime($junk . "/" . $filename)) > ($purge_junk * 60 * 60 * 24)) {
+					$rcmail->write_log('purgefolders', "Purging file " . $filename . " (dated " . date('Y-m-d H:i:s', filemtime($trash . "/" . $filename)) . ") from Junk folder of user " .  $mailboxes[$i]['local_part'] . "@" . $mailboxes[$i]['domain']);
 					unlink($junk . "/" . $filename);
 					$jcount++;
 					}
 				}
 			}
 		}
-	fwrite($log, date('Y-m-d H:i:s') . "       " . $jcount . " messages purged from Junk folder of user " .  $mailboxes[$i]['local_part'] . "@" . $mailboxes[$i]['domain'] . ".\n");
+	$rcmail->write_log('purgefolders', $jcount . " messages purged from Junk folder of user " .  $mailboxes[$i]['local_part'] . "@" . $mailboxes[$i]['domain']);
 	}
 
-fwrite($log, date('Y-m-d H:i:s') . " - Purge operation ended.\n\n");
-fclose($log);
-
-$sql_result->free();
-$db->disconnect();
-
+$rcmail->write_log('purgefolders', "Purge operation ended");
 ?>


### PR DESCRIPTION
**Domain-inherited purge limits**
This pull request contains code to enable postfixadmin users to set purge limits on their domains, where mailboxes by default automatically inherit those values if the user doesn't specify them manually. This has the advantage of not having to change limits for every single mailbox if the limits change at any time.
To further support central administration, a new config setting `purge_visible` allows the settings tab in the UI to be hidden, such that only the mailserver administrator can manage limits.

**Refactored purge script**
The purge script now initializes Roundcube class to access logs and database via framework-provided methods. Also the maildir path is fetched from the database instead of manually constructing it, which greatly enhances adaptability to non-standard server configurations.
